### PR TITLE
Update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /build
 /tests/output
 .tox
+.coverage

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 xlwt
 =================================
+Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS
+files, on any platform, with Python 2.3+ and 3.3+.
+
 .. image:: https://img.shields.io/pypi/v/xlwt.svg
     :target: https://pypi.python.org/pypi/xlwt
 
@@ -8,9 +11,6 @@ xlwt
 
 .. image:: https://coveralls.io/repos/sontek/xlwt/badge.png?branch=add_pytest_tox
            :target: https://coveralls.io/r/sontek/xlwt?branch=add_pytest_tox
-
-Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS
-files, on any platform, with Python 2.3+ and 3.3+.
 
 
 xlwt is a library for generating spreadsheet files that are compatible with

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ xlwt
            :target: https://coveralls.io/r/sontek/xlwt?branch=add_pytest_tox
 
 Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS
-files, on any platform, with Python 2.3 to 2.7
+files, on any platform, with Python 2.3+ and 3.3+.
 
 
 xlwt is a library for generating spreadsheet files that are compatible with

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,19 @@
+xlwt
+=================================
+.. image:: https://img.shields.io/pypi/v/xlwt.svg
+    :target: https://pypi.python.org/pypi/xlwt
+
+.. image:: https://img.shields.io/travis/python-excel/xlwt.svg
+    :target: https://travis-ci.org/python-excel/xlwt
+
+.. image:: https://coveralls.io/repos/sontek/xlwt/badge.png?branch=add_pytest_tox
+           :target: https://coveralls.io/r/sontek/xlwt?branch=add_pytest_tox
+
+Library to create spreadsheet files compatible with MS Excel 97/2000/XP/2003 XLS
+files, on any platform, with Python 2.3 to 2.7
+
+
+xlwt is a library for generating spreadsheet files that are compatible with
+Excel 97/2000/XP/2003, OpenOffice.org Calc, and Gnumeric. xlwt has full support
+for Unicode. Excel spreadsheets can be generated on any platform without needing
+Excel or a COM server.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 nose
 pytest
+pytest-cov
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ commands =
 pip_pre=False
 commands =
     {[base]commands}
-    py.test {posargs} tests/
+    py.test {posargs} --junitxml=junit.xml --cov=xlwt --cov-report=xml --cov-report=term-missing tests/


### PR DESCRIPTION
This adds a README.rst that discusses support for py3 and adds badges for travis-ci and coveralls.

You can see how these kind of look here:

https://github.com/sontek/xlwt/tree/add_pytest_tox
https://coveralls.io/builds/1776961

We will need to enable coveralls for python-excel/xlwt as well.
